### PR TITLE
Simplify CMake flow using an completely ExternalProject loaded in configure step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,92 +1,101 @@
 cmake_minimum_required(VERSION 3.10)
-if (INNER_BUILD)
-    project(lbfgsb_cpp CXX)
-    set(CMAKE_CXX_STANDARD 17)
-else ()
-    project(lbfgsb_cpp_outer_build CXX)
-endif ()
+project(lbfgsb_cpp CXX)
+set(CMAKE_CXX_STANDARD 17)
 
 option(BUILD_EXAMPLE "Build example" OFF)
 
-if (NOT INNER_BUILD)
-    if (CMAKE_GENERATOR MATCHES "Visual Studio")
-        set(LBFGSB_CMAKE_GENERATOR "Unix Makefiles")
-    else()
-        set(LBFGSB_CMAKE_GENERATOR "${CMAKE_GENERATOR}")
-    endif()
-    
-    include(ExternalProject)
-    set(lbfgsb_INSTALL_DIR ${CMAKE_BINARY_DIR}/lbfgsb_installed)
-    ExternalProject_Add(lbfgsb
-            SOURCE_DIR ${CMAKE_SOURCE_DIR}/Lbfgsb.3.0
-            CMAKE_GENERATOR "${LBFGSB_CMAKE_GENERATOR}" # -G as CMAKE_ARGS is not sufficient
-            CMAKE_ARGS
-                -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
-                -DFortran_LINK_FLAGS=${Fortran_LINK_FLAGS}
-                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                -DCMAKE_INSTALL_PREFIX=${lbfgsb_INSTALL_DIR}
-            )
-
-    ExternalProject_Add(main
-            DEPENDS lbfgsb
-            SOURCE_DIR ${CMAKE_SOURCE_DIR}
-            CMAKE_ARGS
-                -DINNER_BUILD=TRUE
-                -DBUILD_EXAMPLE=${BUILD_EXAMPLE}
-                -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                -Dlbfgsb_INSTALL_DIR=${lbfgsb_INSTALL_DIR}
-                -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/installed
-            )
+if (CMAKE_GENERATOR MATCHES "Visual Studio")
+    set(LBFGSB_CMAKE_GENERATOR "Unix Makefiles")
 else ()
-    set(HEADERS "include/${PROJECT_NAME}/lbfgsb.hpp")
-
-    add_library(${PROJECT_NAME} INTERFACE ${HEADERS})
-    add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-
-    set(lbfgsb_DIR "${lbfgsb_INSTALL_DIR}/lib/cmake/lbfgsb")
-    find_package(lbfgsb CONFIG REQUIRED)
-    #target_link_libraries(${PROJECT_NAME} lbfgsb::lbfgsb)
-
-    target_include_directories(
-            ${PROJECT_NAME} INTERFACE
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-            $<INSTALL_INTERFACE:include>
-    )
-    target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
-
-    if (TARGET blas)
-        #    target_link_libraries(${PROJECT_NAME} PUBLIC blas)
-    endif ()
-
-    if (CMAKE_BUILD_TYPE MATCHES "Release")
-    else ()
-        #    target_compile_options(${PROJECT_NAME} PRIVATE -fcheck=all)
-    endif ()
-    
-    # Create install rule for your library. Use variables CMAKE_INSTALL_*DIR defined in GNUInstallDir
-    include(GNUInstallDirs)
-    # https://cmake.org/cmake/help/latest/command/install.html
-    # https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/
-    install(TARGETS ${PROJECT_NAME}
-            EXPORT ${PROJECT_NAME}_targets
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT devel
-            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime
-            PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT devel
-            )
-
-    install(FILES ${HEADERS} DESTINATION "include/${PROJECT_NAME}")
-
-    install(
-            EXPORT ${PROJECT_NAME}_targets
-            FILE ${PROJECT_NAME}Config.cmake
-            NAMESPACE ${PROJECT_NAME}::
-            DESTINATION lib/cmake/${PROJECT_NAME}
-    )
-
+    set(LBFGSB_CMAKE_GENERATOR "${CMAKE_GENERATOR}")
+    set(LBFGSB_CMAKE_GENERATOR "Unix Makefiles") # DEBUG
 endif ()
 
-IF (BUILD_EXAMPLE)
+# Did not use FetchContent since generated CMakeLists.txt doesn't support a different generator for the external project
+set(lbfgsb_BINARY_DIR "${CMAKE_BINARY_DIR}/lbfgsb-build")
+set(lbfgsb_INSTALL_DIR "${CMAKE_BINARY_DIR}/lbfgsb-installed")
+
+# subbuild for lbfgsb
+set(lbfgsb_VIRTUAL_PROJECT "${CMAKE_CURRENT_BINARY_DIR}/lbfgsb-virtual-project")
+configure_file("${CMAKE_SOURCE_DIR}/cmake/ExternalFortranProject.cmake.in"
+        "${lbfgsb_VIRTUAL_PROJECT}/CMakeLists.txt")
+execute_process(
+        COMMAND ${CMAKE_COMMAND}
+        -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
+        -DFortran_LINK_FLAGS="${Fortran_LINK_FLAGS}"
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_INSTALL_PREFIX=${lbfgsb_INSTALL_DIR}
+        .
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE capturedOutput
+        ERROR_VARIABLE capturedOutput
+        WORKING_DIRECTORY "${lbfgsb_VIRTUAL_PROJECT}"
+)
+if (result)
+    message("${capturedOutput}")
+    message(FATAL_ERROR "CMake step for lbfgsb-build failed: ${result}")
+endif ()
+execute_process(
+        COMMAND ${CMAKE_COMMAND} --build .
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE capturedOutput
+        ERROR_VARIABLE capturedOutput
+        WORKING_DIRECTORY "${lbfgsb_VIRTUAL_PROJECT}"
+)
+if (result)
+    message("${capturedOutput}")
+    message(FATAL_ERROR "Build step for lbfgsb-build failed: ${result}")
+endif ()
+# End of subbuild for lbfgsb
+
+set(lbfgsb_DIR "${lbfgsb_INSTALL_DIR}/lib/cmake/lbfgsb")
+find_package(lbfgsb CONFIG REQUIRED)
+
+set(HEADERS "include/${PROJECT_NAME}/lbfgsb.hpp")
+
+add_library(${PROJECT_NAME} INTERFACE ${HEADERS})
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+#target_link_libraries(${PROJECT_NAME} lbfgsb::lbfgsb)
+
+target_include_directories(
+        ${PROJECT_NAME} INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
+
+if (TARGET blas)
+    target_link_libraries(${PROJECT_NAME} PUBLIC blas)
+endif ()
+
+if (CMAKE_BUILD_TYPE MATCHES "Release")
+else ()
+    #    target_compile_options(${PROJECT_NAME} PRIVATE -fcheck=all)
+endif ()
+
+if (BUILD_EXAMPLE)
     enable_testing()
     add_subdirectory(examples)
-ENDIF ()
+endif ()
+
+# Create install rule for your library. Use variables CMAKE_INSTALL_*DIR defined in GNUInstallDir
+include(GNUInstallDirs)
+# https://cmake.org/cmake/help/latest/command/install.html
+# https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}_targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT devel
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT devel
+        )
+
+install(FILES ${HEADERS} DESTINATION "include/${PROJECT_NAME}")
+
+install(
+        EXPORT ${PROJECT_NAME}_targets
+        FILE ${PROJECT_NAME}Config.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION lib/cmake/${PROJECT_NAME}
+)

--- a/Lbfgsb.3.0/CMakeLists.txt
+++ b/Lbfgsb.3.0/CMakeLists.txt
@@ -1,4 +1,17 @@
 cmake_minimum_required(VERSION 3.15)
+
+message(STATUS "Using Fortran compiler: ${CMAKE_Fortran_COMPILER}")
+message(STATUS "Using Fortran library flags: ${Fortran_LINK_FLAGS}")
+
+if (CMAKE_GENERATOR MATCHES "Visual Studio")
+    message(FATAL_ERROR "This project cannot be build using '${CMAKE_GENERATOR}'")
+else()
+    if (NOT CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+        message(FATAL_ERROR "This project cannot be build using '${CMAKE_GENERATOR}'")
+    endif()
+    message(STATUS "Using CMake generator: ${CMAKE_GENERATOR}")
+endif()
+
 project(lbfgsb Fortran)
 
 # Prevent from root system installation
@@ -7,9 +20,6 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     # Force update for sub-libraries (to follow current installation directive)
     set(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT FALSE CACHE BOOL "Installation prefix has been set" FORCE)
 endif ()
-
-message(STATUS "Using Fortran compiler: ${CMAKE_Fortran_COMPILER}")
-message(STATUS "Using Fortran library flags: ${Fortran_LINK_FLAGS}")
 
 set(FORTRAN_SRC
     lbfgsb.F # capital to enable pre-processing with compilation directives

--- a/cmake/ExternalFortranProject.cmake.in
+++ b/cmake/ExternalFortranProject.cmake.in
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
+project(lbfgsb-build NONE)
+include(ExternalProject)
+ExternalProject_Add(lbfgsb-build
+                    SOURCE_DIR          "@CMAKE_SOURCE_DIR@/Lbfgsb.3.0"
+                    BINARY_DIR          "@lbfgsb_BINARY_DIR@"
+                    CMAKE_GENERATOR     "@LBFGSB_CMAKE_GENERATOR@"     
+                    CMAKE_ARGS
+                        "-DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}"
+                        "-DFortran_LINK_FLAGS=${Fortran_LINK_FLAGS}"
+                        "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+                        "-DCMAKE_INSTALL_PREFIX=@lbfgsb_INSTALL_DIR@"
+)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,30 +1,14 @@
-if (INNER_BUILD)
-    add_executable(example example.cpp strncmp_debug.cpp)
-    target_link_libraries(example PRIVATE ${PROJECT_NAME})
-    target_link_libraries(example PRIVATE lbfgsb::lbfgsb)
-    #target_compile_options(
-    #    example PRIVATE
-    #    -Wall
-    #    -Wextra
-    #    -pedantic
-    #    -Wshadow
-    #    -Wdouble-promotion
-    #    -Wnull-dereference
-    #)
+add_executable(example example.cpp strncmp_debug.cpp)
+target_link_libraries(example PRIVATE ${PROJECT_NAME})
+target_link_libraries(example PUBLIC lbfgsb::lbfgsb)
+#target_compile_options(
+#    example PRIVATE
+#    -Wall
+#    -Wextra
+#    -pedantic
+#    -Wshadow
+#    -Wdouble-promotion
+#    -Wnull-dereference
+#)
 
-    add_test(NAME example COMMAND example)
-else ()
-    ExternalProject_Get_property(main binary_dir)
-    set(main_BINARY_DIR ${binary_dir})
-    configure_file("${CMAKE_SOURCE_DIR}/examples/CTestCustom.cmake.in" ${CMAKE_BINARY_DIR}/CTestCustom.cmake)
-    add_test(NAME run-subtests-trigger COMMAND true) # requires at least one even, a dummy one
-    
-    add_custom_target(run-subtests
-            COMMAND ${CMAKE_COMMAND} -E echo "To run custom ctest, run it in ${main_BINARY_DIR}"
-            # COMMAND ${CMAKE_COMMAND} -E echo CWD=${CMAKE_BINARY_DIR}
-            # COMMAND ${CMAKE_COMMAND} -E echo CMD=${CMAKE_CTEST_COMMAND} -C $<CONFIG>
-            # COMMAND ${CMAKE_COMMAND} -E echo ----------------------------------
-            COMMAND ${CMAKE_COMMAND} -E env CTEST_OUTPUT_ON_FAILURE=1 ${CMAKE_CTEST_COMMAND} -C $<CONFIG>
-            WORKING_DIRECTORY ${main_BINARY_DIR}
-            )
-endif ()
+add_test(NAME example COMMAND example)


### PR DESCRIPTION
It allows to use a main CMake as usual (not a ExternalProject)