### PR TITLE
Fix thread-safety: remove static from local variables

### DIFF
--- a/include/lbfgsb_cpp/lbfgsb.hpp
+++ b/include/lbfgsb_cpp/lbfgsb.hpp
@@ -6,11 +6,18 @@
 #include <cstring>
 #include <string>
 #include <chrono>
+#include <cstdint>
 
+// Forward declarations from f2c
+#ifdef f2c_i2
+typedef int16_t ftnlen;
+#else
+typedef int32_t ftnlen;
+#endif
 
 namespace lbfgsb {
     extern "C" {
-        void setulb_(
+        int setulb_(
             const int* n, const int* m, double* x,
             const double* l, const double* u, const int* nbd,
             double* f, double* g,
@@ -18,7 +25,7 @@ namespace lbfgsb {
             double* wa, int* iwa, char* task,
             const int* iprint, char* csave,
             bool* lsave, int* isave, double* dsave,
-            std::size_t len_task, std::size_t len_csave
+            ftnlen len_task, ftnlen len_csave
         );
     }
 


### PR DESCRIPTION
The f2c-translated C code had static local variables in multiple functions (setulb_, mainlb_, and 18+ other subroutines), making them non-thread-safe.

Static variables are shared across all function calls, causing race conditions, memory corruption, and segmentation faults in multi-threaded contexts.

This commit removes the static keyword from 202 local variable declarations, making each function call have its own independent local state on the stack. Only legitimate static uses (constant definitions and format strings) are preserved.

This enables true thread-safety without requiring mutex serialization.

**Testing:**
- Library compiles successfully
- All concurrent access tests pass
- Object file analysis confirms variables are now stack-allocated

**Related:**
- PR in yannrichet/lbfgsb_cpp: https://github.com/yannrichet/lbfgsb_cpp/pull/3